### PR TITLE
updating .gitignore file to avoid loading amazon food reviews input sqlite,.csv files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,9 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# avoding updating amazon reviews dataset as file is huge
+*Reviews.csv
+
+#sqllite objects 
+*.sqlite

--- a/amazon-food-reviews/notebooks/dataset/input/hashes.txt
+++ b/amazon-food-reviews/notebooks/dataset/input/hashes.txt
@@ -1,0 +1,7 @@
+Current git commit:
+18824c4d0fea769ebb0301182d550130e4a08560
+
+Current input/ouput md5 hashes:
+MD5 (output/Reviews.csv) = c3c950ae0be8b0736477c89d052d33fd
+MD5 (output/database.sqlite) = a50334684f230502a9ce984cb749514f
+MD5 (input/Reviews.txt) = 20b122f0d990184a445b84b73aeee074


### PR DESCRIPTION
updating .gitignore file to avoid loading amazon food reviews input sqlite,.csv files